### PR TITLE
Adapt project to zls 0.11.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,10 +11,8 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     exe.addModule("zls", b.dependency("zls", .{}).module("zls"));
-    exe.install();
 
-    const run_cmd = exe.run();
-
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     if (b.args) |args| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "1.0.0",
     .dependencies = .{
         .zls = .{
-            .url = "https://github.com/zigtools/zls/archive/build-runner-param-plus-library.tar.gz",
-            .hash = "1220d72a4bc8e8c934d3854b29e065cbe7d09328c83368b0e658d3f6c0acd7424d92",
+            .url = "https://github.com/zigtools/zls/archive/refs/tags/0.11.0.tar.gz",
+            .hash = "1220ef39b9be17640457ba1a737ebbc664d7b728a84b3e088d89258a115816bf28c9",
         },
     },
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -81,7 +81,7 @@ pub fn main() !void {
                 .line = 4,
                 .character = @intCast(4 + input.len),
             },
-        }) orelse emptyList).?.CompletionList.items;
+        }) orelse emptyList).CompletionList.items;
 
         // We print out the completions
         for (completions) |comp| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -81,7 +81,7 @@ pub fn main() !void {
                 .line = 4,
                 .character = @intCast(4 + input.len),
             },
-        }) orelse emptyList).CompletionList.items;
+        }) orelse emptyList).?.CompletionList.items;
 
         // We print out the completions
         for (completions) |comp| {


### PR DESCRIPTION
This pull request adapts zls as lib demo to zls version 0.11.0.

Things I'm not sure:
- is there any replacement for server.maybeFreeArena
- why unwrap is needed on line 84 even though `orelse` provides default value